### PR TITLE
Optionally ignore designer types during line count

### DIFF
--- a/DebtRatchet.Library/IgnoreDesignerTypes.cs
+++ b/DebtRatchet.Library/IgnoreDesignerTypes.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace DebtRatchet
+{
+	/// <summary>
+	/// Specifies if designer types (e.g. resource files) are ignored when counting lines in types. The default is true.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly)]
+	public class IgnoreDesignerTypes : Attribute
+	{
+		public IgnoreDesignerTypes(bool doIgnore)
+		{
+			DoIgnore = doIgnore;
+		}
+
+		public bool DoIgnore { get; }
+	}
+}

--- a/DebtRatchet/ClassDebt/TypeLengthAnalyzer.cs
+++ b/DebtRatchet/ClassDebt/TypeLengthAnalyzer.cs
@@ -13,6 +13,8 @@ namespace DebtRatchet.ClassDebt
 
 		public static int DefaultMaximumTypeLength = 1000;
 
+		public static bool DefaultIgnoreDesignerTypes = true;
+
 		public void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
 		{
 			var type = (TypeDeclarationSyntax)context.Node;
@@ -58,6 +60,12 @@ namespace DebtRatchet.ClassDebt
 		{
 			return assembly.GetAttributes().Where(data => data.AttributeClass.Name == typeof(MaxTypeLength).Name && data.ConstructorArguments.Length == 1).
 				Select(data => data.ConstructorArguments[0].Value as int?).FirstOrDefault() ?? DefaultMaximumTypeLength;
+		}
+
+		public static bool GetIgnoreDesignerTypes(IAssemblySymbol assembly)
+		{
+			return assembly.GetAttributes().Where(data => data.AttributeClass.Name == typeof(IgnoreDesignerTypes).Name && data.ConstructorArguments.Length == 1).
+				       Select(data => data.ConstructorArguments[0].Value as bool?).FirstOrDefault() ?? DefaultIgnoreDesignerTypes;
 		}
 	}
 }


### PR DESCRIPTION
Designer types (e.g. resource files: *.Designer.cs) can now be ignored when counting debt.
These types do not get a TypeHasDebt, but are counted in the statistics provider.